### PR TITLE
use golang.org/x/sys/windows

### DIFF
--- a/files/is_hidden_windows.go
+++ b/files/is_hidden_windows.go
@@ -5,7 +5,8 @@ package files
 import (
 	"path/filepath"
 	"strings"
-	"syscall"
+
+	windows "golang.org/x/sys/windows"
 )
 
 func IsHidden(f File) bool {
@@ -16,14 +17,14 @@ func IsHidden(f File) bool {
 		return true
 	}
 
-	p, e := syscall.UTF16PtrFromString(f.FileName())
+	p, e := windows.UTF16PtrFromString(f.FullPath())
 	if e != nil {
 		return false
 	}
 
-	attrs, e := syscall.GetFileAttributes(p)
+	attrs, e := windows.GetFileAttributes(p)
 	if e != nil {
 		return false
 	}
-	return attrs&syscall.FILE_ATTRIBUTE_HIDDEN != 0
+	return attrs&windows.FILE_ATTRIBUTE_HIDDEN != 0
 }

--- a/option.go
+++ b/option.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gx/ipfs/QmWbjfz3u6HkAdPh34dgPchGbQjob6LXLhAeCGii2TX69n/go-ipfs-util"
+	"github.com/ipfs/go-ipfs-util"
 )
 
 // Types of Command options

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
       "hash": "QmWbjfz3u6HkAdPh34dgPchGbQjob6LXLhAeCGii2TX69n",
       "name": "go-ipfs-util",
       "version": "1.2.4"
+    },
+    {
+      "author": "The Go Authors",
+      "hash": "QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT",
+      "name": "sys",
+      "version": "0.1.0"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
syscall is mostly deprecated

This PR also unrewrites a gx dependency (we usually only leave dependencies
rewritten in go-ipfs).