### PR TITLE
Fall back to "application/octet-stream" if content type is not set

### DIFF
--- a/files/multipartfile.go
+++ b/files/multipartfile.go
@@ -46,6 +46,8 @@ func NewFileFromPart(part *multipart.Part) (File, error) {
 			Target: string(out),
 			name:   f.FileName(),
 		}, nil
+	case "": // default to application/octet-stream
+		fallthrough
 	case applicationFile:
 		return &ReaderFile{
 			reader:   part,

--- a/option.go
+++ b/option.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/ipfs/go-ipfs-util"
 )
 
 // Types of Command options
@@ -224,7 +222,7 @@ func (ov *OptionValue) Bool() (value bool, found bool, err error) {
 	}
 	val, ok := ov.Value.(bool)
 	if !ok {
-		err = util.ErrCast()
+		err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
 	}
 	return val, ov.ValueFound, err
 }
@@ -235,7 +233,7 @@ func (ov *OptionValue) Int() (value int, found bool, err error) {
 	}
 	val, ok := ov.Value.(int)
 	if !ok {
-		err = util.ErrCast()
+		err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
 	}
 	return val, ov.ValueFound, err
 }
@@ -246,7 +244,7 @@ func (ov *OptionValue) Uint() (value uint, found bool, err error) {
 	}
 	val, ok := ov.Value.(uint)
 	if !ok {
-		err = util.ErrCast()
+		err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
 	}
 	return val, ov.ValueFound, err
 }
@@ -257,7 +255,7 @@ func (ov *OptionValue) Float() (value float64, found bool, err error) {
 	}
 	val, ok := ov.Value.(float64)
 	if !ok {
-		err = util.ErrCast()
+		err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
 	}
 	return val, ov.ValueFound, err
 }
@@ -268,7 +266,7 @@ func (ov *OptionValue) String() (value string, found bool, err error) {
 	}
 	val, ok := ov.Value.(string)
 	if !ok {
-		err = util.ErrCast()
+		err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
 	}
 	return val, ov.ValueFound, err
 }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,6 @@
   },
   "gxDependencies": [
     {
-      "author": "whyrusleeping",
-      "hash": "QmPsAfmDBnZN3kZGSuNwvCNDZiHneERSKmRcFyG3UkvcT3",
-      "name": "go-ipfs-util",
-      "version": "1.2.6"
-    },
-    {
       "author": "The Go Authors",
       "hash": "QmPXvegq26x982cQjSfbTvSzZXn7GiaMwhhVPHkeTEhrPT",
       "name": "sys",


### PR DESCRIPTION
For some reason sharness test t0410 fails for me. It uses curl to call ipfs add, which fails with the error `"mime: no media type"`, which originates [here](https://github.com/ipfs/go-ipfs-cmdkit/compare/feat/content-type-fallback?expand=1#diff-71436e45f03d7fe18ccbe2be353e4647L59).
The reason is that curl does not set the content-type HTTP header.

I have no idea why the test fails for me locally, but not on CI. Anyway, this fixes it.