### PR TITLE
changes for cmdkit1.0.0

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -6,52 +6,90 @@ import (
 )
 
 func TestMarshal(t *testing.T) {
-	e := Error{
-		Message: "error msg",
+	type testcase struct {
+		msg  string
+		code ErrorType
 	}
 
-	buf, err := json.Marshal(e)
-	if err != nil {
-		t.Fatal(err)
+	tcs := []testcase{
+		{msg: "error msg", code: 0},
+		{msg: "error msg", code: 1},
+		{msg: "some other error msg", code: 1},
 	}
 
-	m := make(map[string]interface{})
+	for _, tc := range tcs {
+		e := Error{
+			Message: tc.msg,
+			Code:    tc.code,
+		}
 
-	err = json.Unmarshal(buf, &m)
-	if err != nil {
-		t.Fatal(err)
+		buf, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m := make(map[string]interface{})
+
+		err = json.Unmarshal(buf, &m)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(m) != 3 {
+			t.Errorf("expected three map elements, got ", len(m))
+		}
+
+		if m["Message"].(string) != tc.msg {
+			t.Errorf(`expected m["Message"] to be %q, got %q`, tc.msg, m["Message"])
+		}
+
+		icode := ErrorType(m["Code"].(float64))
+		if icode != tc.code {
+			t.Errorf(`expected m["Code"] to be %v, got %v`, tc.code, icode)
+		}
+
+		if m["Type"].(string) != "error" {
+			t.Errorf(`expected m["Type"] to be %q, got %q`, "error", m["Type"])
+		}
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	type testcase struct {
+		json string
+		msg  string
+		code ErrorType
+
+		err string
 	}
 
-	if len(m) != 3 {
-		t.Fatal("expected three map elements, got ", len(m))
+	tcs := []testcase{
+		{json: `{"Message":"error msg","Code":0}`, msg: "error msg", err: "not of type error"},
+		{json: `{"Message":"error msg","Code":0,"Type":"error"}`, msg: "error msg"},
+		{json: `{"Message":"error msg","Code":1,"Type":"error"}`, msg: "error msg", code: 1},
+		{json: `{"Message":"some other error msg","Code":1,"Type":"error"}`, msg: "some other error msg", code: 1},
 	}
 
-	if m["Message"].(string) != "error msg" {
-		t.Fatal(`expected m["Message"] == "error msg", got "`, m["Message"], `"`)
-	}
+	for i, tc := range tcs {
+		t.Log("at test case", i)
+		var e Error
+		err := json.Unmarshal([]byte(tc.json), &e)
+		if err != nil && err.Error() != tc.err {
+			t.Errorf("expected parse error %q but got %q", tc.err, err)
+		} else if err == nil && tc.err != "" {
+			t.Errorf("expected parse error %q but got %q", tc.err, err)
+		}
 
-	if m["Code"].(float64) != 0 {
-		t.Fatal(`expected m["Code"] == 0, got "`, m["Code"], `"`)
-	}
+		if err != nil {
+			continue
+		}
 
-	if m["Type"].(string) != "error" {
-		t.Fatal(`expected m["Type"] == "error", got "`, m["Type"], `"`)
-	}
+		if e.Message != tc.msg {
+			t.Errorf("expected e.Message to be %q, got %q", tc.msg, e.Message)
+		}
 
-	e = Error{}
-	t.Logf("%s\n", buf)
-
-	err = json.Unmarshal(buf, &e)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("%#v\n", e)
-
-	if e.Message != "error msg" {
-		t.Fatal(`expected e.Message == "error msg", got "` + e.Message + `"`)
-	}
-
-	if e.Code != 0 {
-		t.Fatal(`expected e.Code == 0, got "`, e.Code, `"`)
+		if e.Code != tc.code {
+			t.Errorf("expected e.Code to be %q, got %q", tc.code, e.Code)
+		}
 	}
 }

--- a/option.go
+++ b/option.go
@@ -17,35 +17,18 @@ const (
 	String  = reflect.String
 )
 
-// Flag names
-const (
-	EncShort   = "enc"
-	EncLong    = "encoding"
-	RecShort   = "r"
-	RecLong    = "recursive"
-	ChanOpt    = "stream-channels"
-	TimeoutOpt = "timeout"
-)
-
-// options that are used by this package
-var OptionEncodingType = StringOption(EncLong, EncShort, "The encoding type the output should be encoded with (json, xml, or text)").WithCanonicalName(EncLong)
-var OptionRecursivePath = BoolOption(RecLong, RecShort, "Add directory paths recursively").WithDefault(false).WithCanonicalName(RecLong)
-var OptionStreamChannels = BoolOption(ChanOpt, "Stream channel output")
-var OptionTimeout = StringOption(TimeoutOpt, "set a global timeout on the command")
-
 type OptMap map[string]interface{}
 
 // Option is used to specify a field that will be provided by a consumer
 type Option interface {
-	Names() []string     // a list of unique names matched with user-provided flags
+	Name() string    // the main name of the option
+	Names() []string // a list of unique names matched with user-provided flags
+
 	Type() reflect.Kind  // value must be this type
 	Description() string // a short string that describes this option
 
 	WithDefault(interface{}) Option // sets the default value of the option
 	Default() interface{}
-
-	WithCanonicalName(string) Option // sets a canonical name for the option
-	CanonicalName() (string, bool)
 
 	Parse(str string) (interface{}, error)
 }
@@ -55,10 +38,10 @@ type option struct {
 	kind        reflect.Kind
 	description string
 	defaultVal  interface{}
+}
 
-	// canonical name
-	cname    string
-	cnameSet bool
+func (o *option) Name() string {
+	return o.names[0]
 }
 
 func (o *option) Names() []string {
@@ -153,28 +136,6 @@ func (o *option) WithDefault(v interface{}) Option {
 
 func (o *option) Default() interface{} {
 	return o.defaultVal
-}
-
-func (o *option) WithCanonicalName(cname string) Option {
-	o.cname = cname
-	o.cnameSet = true
-
-	var contained bool
-	for _, name := range o.names {
-		if name == cname {
-			contained = true
-		}
-	}
-
-	if !contained {
-		o.names = append(o.names, cname)
-	}
-
-	return o
-}
-
-func (o *option) CanonicalName() (string, bool) {
-	return o.cname, o.cnameSet
 }
 
 // TODO handle description separately. this will take care of the panic case in

--- a/option.go
+++ b/option.go
@@ -114,13 +114,12 @@ func (o *option) Parse(v string) (interface{}, error) {
 
 // constructor helper functions
 func NewOption(kind reflect.Kind, names ...string) Option {
-	if len(names) < 2 {
-		// FIXME(btc) don't panic (fix_before_merge)
-		panic("Options require at least two string values (name and description)")
-	}
+	var desc string
 
-	desc := names[len(names)-1]
-	names = names[:len(names)-1]
+	if len(names) >= 2 {
+		desc = names[len(names)-1]
+		names = names[:len(names)-1]
+	}
 
 	return &option{
 		names:       names,

--- a/option_test.go
+++ b/option_test.go
@@ -1,6 +1,7 @@
 package cmdkit
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -41,5 +42,77 @@ func TestDotIsAddedInDescripton(t *testing.T) {
 	dest := opt.Description()
 	if !strings.HasSuffix(dest, ".") {
 		t.Fatal("dot should have been added at the end of description")
+	}
+}
+
+func TestOptionName(t *testing.T) {
+	exp := map[string]interface{}{
+		"Name()":  "main",
+		"Names()": []string{"main", "m", "alias"},
+	}
+
+	assert := func(name string, value interface{}) {
+		if !reflect.DeepEqual(value, exp[name]) {
+			t.Errorf(`expected %s to return %q, got %q`, name, exp[name], value)
+		}
+	}
+
+	opt := StringOption("main", "m", "alias", `an option with main name "main" and "m" and "alias" as aliases`)
+	assert("Name()", opt.Name())
+	assert("Names()", opt.Names())
+}
+
+func TestParse(t *testing.T) {
+	type testcase struct {
+		opt Option
+		str string
+		v   interface{}
+		err string
+	}
+
+	tcs := []testcase{
+		{opt: StringOption("str"), str: "i'm a string!", v: "i'm a string!"},
+		{opt: IntOption("int1"), str: "42", v: 42},
+		{opt: IntOption("int1"), str: "fourtytwo", err: `strconv.ParseInt: parsing "fourtytwo": invalid syntax`},
+		{opt: IntOption("int2"), str: "-42", v: -42},
+		{opt: UintOption("uint1"), str: "23", v: 23},
+		{opt: UintOption("uint2"), str: "-23", err: `strconv.ParseUint: parsing "-23": invalid syntax`},
+		{opt: BoolOption("true"), str: "true", v: true},
+		{opt: BoolOption("true"), str: "", v: true},
+		{opt: BoolOption("false"), str: "false", v: false},
+		{opt: FloatOption("float"), str: "2.718281828459045", v: 2.718281828459045},
+	}
+
+	for _, tc := range tcs {
+		v, err := tc.opt.Parse(tc.str)
+		if err != nil && err.Error() != tc.err {
+			t.Errorf("unexpected error: %s", err)
+		} else if err == nil && tc.err != "" {
+			t.Errorf("expected error %q but got nil")
+		}
+
+		if v != tc.v {
+			t.Error("expected %v but got %v", tc.v, v)
+		}
+	}
+}
+
+func TestDescription(t *testing.T) {
+	type testcase struct {
+		opt  Option
+		desc string
+	}
+
+	tcs := []testcase{
+		{opt: StringOption("str", "some random option"), desc: "some random option."},
+		{opt: StringOption("str", "some random option (<<default>>)"), desc: "some random option (<<default>>)."},
+		{opt: StringOption("str", "some random option (<<default>>)").WithDefault("random=4"), desc: "some random option (Default: random=4.)."},
+		{opt: StringOption("str", "some random option").WithDefault("random=4"), desc: "some random option. Default: random=4."},
+	}
+
+	for _, tc := range tcs {
+		if desc := tc.opt.Description(); desc != tc.desc {
+			t.Errorf("expected\n%q\nbut got\n%q", tc.desc, desc)
+		}
 	}
 }


### PR DESCRIPTION
Overview of changes:

- remove CanonicalName - instead, the first name passed will be used in the option maps
- don't panic when no description is passed, just leave it empty
  - this is still weird, maybe we should change the signature to `func(dest string, names ...string)` but that requires changes all over the place and cmds and go-ipfs/core/commands is already very much in flux now
- move predefined options to cmds (encoding, ...)
- don't use go-ipfs-util for type errors, instead use simple Errorf
- more tests
- includes #8 

TODO before merge:
- ~~change version number in package.json to 1.0.0~~
- ~~squash~~