### PR TITLE
Allow implicit int to uint conversion

### DIFF
--- a/option.go
+++ b/option.go
@@ -204,7 +204,12 @@ func (ov *OptionValue) Uint() (value uint, found bool, err error) {
 	}
 	val, ok := ov.Value.(uint)
 	if !ok {
-		err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
+		intval, ok := ov.Value.(int)
+		if ok && intval >= 0 {
+			val = uint(intval)
+		} else {
+			err = fmt.Errorf("expected type %T, got %T", val, ov.Value)
+		}
 	}
 	return val, ov.ValueFound, err
 }

--- a/option_test.go
+++ b/option_test.go
@@ -32,6 +32,17 @@ func TestOptionValueExtractWrongType(t *testing.T) {
 	}
 }
 
+func TestOptionValueExtractEquivalentType(t *testing.T) {
+	optval := &OptionValue{Value: int(5), ValueFound: true}
+	uintval, _, err := optval.Uint()
+	if err != nil {
+		t.Fatalf("Int should be equivalent to uint but got %s", err)
+	}
+	if uintval != 5 {
+		t.Fatalf("Expected 5 but got %d", uintval)
+	}
+}
+
 func TestLackOfDescriptionOfOptionDoesNotPanic(t *testing.T) {
 	opt := BoolOption("a", "")
 	opt.Description()


### PR DESCRIPTION
Note this fixes an issue parsing command line arguments, eg:
```
cmdkit.UintOption("dht-record-count", "dhtrc", "...")

// ...

// Error at this line because UintOption above is parsed to int:
rc, rcok, _ := req.Option("dht-record-count").Uint()
```