### PR TITLE
Feat: add WebFile File implementation.

### DIFF
--- a/files/webfile.go
+++ b/files/webfile.go
@@ -1,0 +1,68 @@
+package files
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+)
+
+// WebFile is an implementation of File which reads it
+// from a Web URL (http). A GET request will be performed
+// against the source when calling Read().
+type WebFile struct {
+	body io.ReadCloser
+	url  *url.URL
+}
+
+// NewWebFile creates a WebFile with the given URL, which
+// will be used to perform the GET request on Read().
+func NewWebFile(url *url.URL) *WebFile {
+	return &WebFile{
+		url: url,
+	}
+}
+
+// Read reads the File from it's web location. On the first
+// call to Read, a GET request will be performed against the
+// WebFile's URL, using Go's default HTTP client. Any further
+// reads will keep reading from the HTTP Request body.
+func (wf *WebFile) Read(b []byte) (int, error) {
+	if wf.body == nil {
+		resp, err := http.Get(wf.url.String())
+		if err != nil {
+			return 0, err
+		}
+		wf.body = resp.Body
+	}
+	return wf.body.Read(b)
+}
+
+// Close closes the WebFile (or the request body).
+func (wf *WebFile) Close() error {
+	if wf.body == nil {
+		return nil
+	}
+	return wf.body.Close()
+}
+
+// FullPath returns the "Host+Path" for this WebFile.
+func (wf *WebFile) FullPath() string {
+	return wf.url.Host + wf.url.Path
+}
+
+// FileName returns the last element of the URL
+// path for this file.
+func (wf *WebFile) FileName() string {
+	return filepath.Base(wf.url.Path)
+}
+
+// IsDirectory returns false.
+func (wf *WebFile) IsDirectory() bool {
+	return false
+}
+
+// NextFile always returns an ErrNotDirectory error.
+func (wf *WebFile) NextFile() (File, error) {
+	return nil, ErrNotDirectory
+}

--- a/files/webfile_test.go
+++ b/files/webfile_test.go
@@ -1,0 +1,38 @@
+package files
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestWebFile(t *testing.T) {
+	http.HandleFunc("/my/url/content.txt", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello world!")
+	})
+	listener, err := net.Listen("tcp", ":18281")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		http.Serve(listener, nil)
+	}()
+
+	u, err := url.Parse("http://127.0.0.1:18281/my/url/content.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf := NewWebFile(u)
+	body, err := ioutil.ReadAll(wf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "Hello world!" {
+		t.Fatal("should have read the web file")
+	}
+}

--- a/files/webfile_test.go
+++ b/files/webfile_test.go
@@ -3,8 +3,8 @@ package files
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 )
@@ -13,17 +13,13 @@ func TestWebFile(t *testing.T) {
 	http.HandleFunc("/my/url/content.txt", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello world!")
 	})
-	listener, err := net.Listen("tcp", ":18281")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer listener.Close()
 
-	go func() {
-		http.Serve(listener, nil)
-	}()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello world!")
+	}))
+	defer s.Close()
 
-	u, err := url.Parse("http://127.0.0.1:18281/my/url/content.txt")
+	u, err := url.Parse(s.URL)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A WebFile is a File which is read from a Web URL using a GET request.

This is used by cluster. I'd rather have it live here than in our code. The idea is that this allows to have `ipfs add http://somehwere/something.jpg` work rather easily.